### PR TITLE
feat(#59): 주문 생성 시 Product Service 검증 연동

### DIFF
--- a/common/src/main/java/com/msa/commerce/common/config/RestClientFactory.java
+++ b/common/src/main/java/com/msa/commerce/common/config/RestClientFactory.java
@@ -1,0 +1,32 @@
+package com.msa.commerce.common.config;
+
+import java.net.http.HttpClient;
+
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+public final class RestClientFactory {
+
+    private RestClientFactory() {
+    }
+
+    public static RestClient create(RestClientProperties properties) {
+        return RestClient.builder()
+            .baseUrl(properties.baseUrl())
+            .requestFactory(requestFactory(properties))
+            .build();
+    }
+
+    // 4xx/5xx는 RestClient 기본 동작(HttpClientErrorException/HttpServerErrorException)에 맡겨
+    // 호출부가 상태 코드별로 분기할 수 있도록 한다.
+    private static JdkClientHttpRequestFactory requestFactory(RestClientProperties properties) {
+        HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(properties.connectTimeout())
+            .build();
+
+        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(httpClient);
+        requestFactory.setReadTimeout(properties.readTimeout());
+        return requestFactory;
+    }
+
+}

--- a/common/src/main/java/com/msa/commerce/common/config/RestClientProperties.java
+++ b/common/src/main/java/com/msa/commerce/common/config/RestClientProperties.java
@@ -1,0 +1,26 @@
+package com.msa.commerce.common.config;
+
+import java.time.Duration;
+
+public record RestClientProperties(String baseUrl, Duration connectTimeout, Duration readTimeout) {
+
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(10);
+
+    public RestClientProperties {
+        if (baseUrl == null || baseUrl.isBlank()) {
+            throw new IllegalArgumentException("Base URL is required");
+        }
+        connectTimeout = connectTimeout != null ? connectTimeout : DEFAULT_TIMEOUT;
+        readTimeout = readTimeout != null ? readTimeout : DEFAULT_TIMEOUT;
+    }
+
+    public static RestClientProperties of(String baseUrl) {
+        return new RestClientProperties(baseUrl, DEFAULT_TIMEOUT, DEFAULT_TIMEOUT);
+    }
+
+    public static RestClientProperties of(String baseUrl, long timeoutMillis) {
+        Duration timeout = Duration.ofMillis(timeoutMillis);
+        return new RestClientProperties(baseUrl, timeout, timeout);
+    }
+
+}

--- a/common/src/main/java/com/msa/commerce/common/exception/ExternalServiceException.java
+++ b/common/src/main/java/com/msa/commerce/common/exception/ExternalServiceException.java
@@ -1,0 +1,17 @@
+package com.msa.commerce.common.exception;
+
+public class ExternalServiceException extends InternalException {
+
+    public ExternalServiceException(String message) {
+        super(message, ErrorCode.EXTERNAL_SERVICE_ERROR.getCode());
+    }
+
+    public ExternalServiceException(String message, String errorCode) {
+        super(message, errorCode);
+    }
+
+    public ExternalServiceException(String message, String errorCode, Throwable cause) {
+        super(message, errorCode, cause);
+    }
+
+}

--- a/common/src/main/java/com/msa/commerce/common/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/msa/commerce/common/exception/GlobalExceptionHandler.java
@@ -241,6 +241,8 @@ public class GlobalExceptionHandler {
             return HttpStatus.BAD_REQUEST;
         } else if (ex instanceof NoChangesProvidedException) {
             return HttpStatus.BAD_REQUEST;
+        } else if (ex instanceof ExternalServiceException) {
+            return HttpStatus.SERVICE_UNAVAILABLE;
         }
         // 기본값
         return HttpStatus.BAD_REQUEST;

--- a/docs/api-specs/order-orchestrator-openapi.yml
+++ b/docs/api-specs/order-orchestrator-openapi.yml
@@ -146,7 +146,6 @@ paths:
                   value:
                     timestamp: "2025-10-25T10:30:00"
                     status: 400
-                    error: "Bad Request"
                     message: "Cannot change order status from PENDING to PROCESSING"
                     path: "/api/v1/orders/550e8400-e29b-41d4-a716-446655440000/status"
                 missingReason:
@@ -154,7 +153,6 @@ paths:
                   value:
                     timestamp: "2025-10-25T10:30:00"
                     status: 400
-                    error: "Bad Request"
                     message: "Reason is required"
                     path: "/api/v1/orders/550e8400-e29b-41d4-a716-446655440000/status"
                     validationErrors:
@@ -170,7 +168,7 @@ paths:
               example:
                 timestamp: "2025-10-25T10:30:00"
                 status: 404
-                error: "Not Found"
+                code: "ORDER_NOT_FOUND"
                 message: "Order not found with ID: 550e8400-e29b-41d4-a716-446655440000"
                 path: "/api/v1/orders/550e8400-e29b-41d4-a716-446655440000/status"
         '500':
@@ -316,7 +314,7 @@ paths:
               example:
                 timestamp: "2025-10-25T10:30:00"
                 status: 404
-                error: "Not Found"
+                code: "ORDER_NOT_FOUND"
                 message: "주문을 찾을 수 없습니다. orderId: 550e8400-e29b-41d4-a716-446655440000"
                 path: "/api/v1/orders/550e8400-e29b-41d4-a716-446655440000"
         '500':
@@ -515,7 +513,6 @@ paths:
                   value:
                     timestamp: "2025-10-25T10:30:00"
                     status: 400
-                    error: "Bad Request"
                     message: "시작 일시는 종료 일시보다 이전이어야 합니다."
                     path: "/api/v1/orders"
                 missingEndDate:
@@ -523,7 +520,6 @@ paths:
                   value:
                     timestamp: "2025-10-25T10:30:00"
                     status: 400
-                    error: "Bad Request"
                     message: "시작 일시와 종료 일시는 필수입니다."
                     path: "/api/v1/orders"
         '500':
@@ -532,6 +528,86 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+
+    post:
+      tags: [Order Command]
+      summary: Create Order
+      description: |
+        Creates a new order.
+
+        ### Product Verification
+        Product name, SKU and unit price are **never taken from the request body**.
+        The service calls `POST /api/v1/products/verify` on the Product Service and
+        persists the verified values, so a client cannot tamper with the order amount.
+
+        ### Business Rules
+        - Every requested product must be available; otherwise the order is rejected
+        - Initial order status is `PENDING`
+        - An `order.created` event is published through the transactional outbox
+      operationId: createOrder
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateOrderRequest'
+            examples:
+              default:
+                summary: Two-item order
+                value:
+                  orderNumber: "ORD-20260726-0001"
+                  customerId: 1
+                  shippingAddress:
+                    zipCode: "06236"
+                    addressLine1: "서울특별시 강남구 테헤란로 123"
+                    addressLine2: "4층"
+                    recipientName: "홍길동"
+                    phoneNumber: "010-1234-5678"
+                  sourceChannel: "WEB"
+                  orderItems:
+                    - productId: 101
+                      quantity: 2
+                    - productId: 205
+                      productVariantId: 3
+                      variantName: "Black / L"
+                      quantity: 1
+      responses:
+        '201':
+          description: Order created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateOrderResponse'
+        '400':
+          description: Validation failed, or one of the products is not available
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                productUnavailable:
+                  summary: Product Not Available
+                  value:
+                    timestamp: "2026-07-26T10:30:00"
+                    status: 400
+                    code: "PRODUCT_UNAVAILABLE"
+                    message: "Products are not available for order: productId=101(재고 부족)"
+                    path: "/api/v1/orders"
+        '503':
+          description: Product Service is unreachable, so the order cannot be verified
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                productServiceDown:
+                  summary: Product Service Unavailable
+                  value:
+                    timestamp: "2026-07-26T10:30:00"
+                    status: 503
+                    code: "PRODUCT_SERVICE_ERROR"
+                    message: "Failed to verify products"
+                    path: "/api/v1/orders"
 
 components:
   securitySchemes:
@@ -865,6 +941,77 @@ components:
           description: Is this the last page?
           example: false
 
+    CreateOrderRequest:
+      type: object
+      required:
+        - orderNumber
+        - customerId
+        - shippingAddress
+        - orderItems
+      properties:
+        orderNumber:
+          type: string
+          description: 주문 번호
+          example: "ORD-20260726-0001"
+        customerId:
+          type: integer
+          format: int64
+          description: 주문 고객 ID
+          example: 1
+        shippingAddress:
+          type: object
+          description: 배송지 정보 (JSON 컬럼으로 저장)
+          additionalProperties: true
+        sourceChannel:
+          type: string
+          description: 주문 유입 채널. 미지정 시 WEB
+          default: WEB
+          example: "WEB"
+        orderItems:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/CreateOrderItemRequest'
+
+    CreateOrderItemRequest:
+      type: object
+      description: |
+        상품명·SKU·단가는 요청에 포함하지 않는다.
+        Product Service 검증 응답에서 확정되므로 클라이언트가 지정할 수 없다.
+      required:
+        - productId
+        - quantity
+      properties:
+        productId:
+          type: integer
+          format: int64
+          example: 101
+        productVariantId:
+          type: integer
+          format: int64
+          nullable: true
+          description: 변형 상품 ID
+          example: 3
+        variantName:
+          type: string
+          nullable: true
+          example: "Black / L"
+        quantity:
+          type: integer
+          minimum: 1
+          example: 2
+
+    CreateOrderResponse:
+      type: object
+      properties:
+        orderId:
+          type: string
+          format: uuid
+          example: "0199a1f2-3c4d-7e8f-9a0b-1c2d3e4f5a6b"
+        message:
+          type: string
+          example: "Order created successfully"
+
     OrderStatusChangeRequest:
       type: object
       required:
@@ -913,23 +1060,31 @@ components:
       required:
         - timestamp
         - status
-        - error
         - message
         - path
       properties:
         timestamp:
           type: string
-          format: date-time
-          description: Error occurrence timestamp
+          description: |
+            Error occurrence timestamp. Serialized from LocalDateTime,
+            so it carries no timezone offset and is not RFC 3339 date-time.
           example: "2025-10-25T10:30:00"
         status:
           type: integer
           description: HTTP status code
           example: 404
-        error:
+        code:
           type: string
-          description: HTTP status text
-          example: "Not Found"
+          nullable: true
+          description: |
+            Business error code. Null for framework-level validation failures
+            that do not originate from a domain exception.
+          example: "ORDER_NOT_FOUND"
+        debugInfo:
+          type: string
+          nullable: true
+          description: Exception class name. Populated only in non-production profiles.
+          example: "OrderNotFoundException"
         message:
           type: string
           description: Error message

--- a/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/adapter/in/web/dto/request/CreateOrderRequest.java
+++ b/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/adapter/in/web/dto/request/CreateOrderRequest.java
@@ -1,6 +1,5 @@
 package com.msa.commerce.orchestrator.adapter.in.web.dto.request;
 
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
@@ -36,6 +35,7 @@ public class CreateOrderRequest {
     @Valid
     private List<OrderItemRequest> orderItems;
 
+    // 상품명/SKU/단가는 클라이언트 입력을 신뢰하지 않고 Product Service 검증 결과에서 확정한다.
     @Getter
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor
@@ -45,12 +45,6 @@ public class CreateOrderRequest {
         @NotNull(message = "Product ID is required")
         private Long productId;
 
-        @NotBlank(message = "Product name is required")
-        private String productName;
-
-        @NotBlank(message = "Product SKU is required")
-        private String productSku;
-
         private Long productVariantId;
 
         private String variantName;
@@ -58,9 +52,6 @@ public class CreateOrderRequest {
         @NotNull(message = "Quantity is required")
         @Positive(message = "Quantity must be positive")
         private Integer quantity;
-
-        @NotNull(message = "Unit price is required")
-        private BigDecimal unitPrice;
 
     }
 

--- a/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/adapter/out/product/ProductServiceException.java
+++ b/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/adapter/out/product/ProductServiceException.java
@@ -1,0 +1,17 @@
+package com.msa.commerce.orchestrator.adapter.out.product;
+
+import com.msa.commerce.common.exception.ExternalServiceException;
+
+public class ProductServiceException extends ExternalServiceException {
+
+    private static final String ERROR_CODE = "PRODUCT_SERVICE_ERROR";
+
+    public ProductServiceException(String message) {
+        super(message, ERROR_CODE);
+    }
+
+    public ProductServiceException(String message, Throwable cause) {
+        super(message, ERROR_CODE, cause);
+    }
+
+}

--- a/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/adapter/out/product/ProductVerifyAdapter.java
+++ b/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/adapter/out/product/ProductVerifyAdapter.java
@@ -1,0 +1,56 @@
+package com.msa.commerce.orchestrator.adapter.out.product;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import com.msa.commerce.orchestrator.adapter.out.product.dto.ProductVerifyApiRequest;
+import com.msa.commerce.orchestrator.adapter.out.product.dto.ProductVerifyApiResponse;
+import com.msa.commerce.orchestrator.application.port.out.ProductPort;
+import com.msa.commerce.orchestrator.domain.vo.ProductVerification;
+import com.msa.commerce.orchestrator.domain.vo.ProductVerificationItem;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class ProductVerifyAdapter implements ProductPort {
+
+    private static final String VERIFY_PATH = "/api/v1/products/verify";
+
+    private final RestClient productRestClient;
+
+    public ProductVerifyAdapter(@Qualifier("productRestClient") RestClient productRestClient) {
+        this.productRestClient = productRestClient;
+    }
+
+    @Override
+    public ProductVerification verify(List<ProductVerificationItem> items) {
+        try {
+            return toDomain(requestVerification(items));
+        } catch (RestClientException e) {
+            log.error("Product verification request failed for {} item(s)", items.size(), e);
+            throw new ProductServiceException("Failed to verify products", e);
+        }
+    }
+
+    private ProductVerifyApiResponse requestVerification(List<ProductVerificationItem> items) {
+        return productRestClient.post()
+            .uri(VERIFY_PATH)
+            .body(ProductVerifyApiRequest.from(items))
+            .retrieve()
+            .body(ProductVerifyApiResponse.class);
+    }
+
+    // ProductServiceException은 RestClientException이 아니므로 위 catch에 다시 잡히지 않는다.
+    private ProductVerification toDomain(ProductVerifyApiResponse response) {
+        if (response == null) {
+            throw new ProductServiceException("Product service returned an empty verification response");
+        }
+        return response.toDomain();
+    }
+
+}

--- a/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/adapter/out/product/dto/ProductVerifyApiRequest.java
+++ b/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/adapter/out/product/dto/ProductVerifyApiRequest.java
@@ -1,0 +1,18 @@
+package com.msa.commerce.orchestrator.adapter.out.product.dto;
+
+import java.util.List;
+
+import com.msa.commerce.orchestrator.domain.vo.ProductVerificationItem;
+
+public record ProductVerifyApiRequest(List<Item> items) {
+
+    public static ProductVerifyApiRequest from(List<ProductVerificationItem> items) {
+        return new ProductVerifyApiRequest(items.stream()
+            .map(item -> new Item(item.productId(), item.quantity()))
+            .toList());
+    }
+
+    public record Item(Long productId, Integer quantity) {
+    }
+
+}

--- a/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/adapter/out/product/dto/ProductVerifyApiResponse.java
+++ b/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/adapter/out/product/dto/ProductVerifyApiResponse.java
@@ -1,0 +1,43 @@
+package com.msa.commerce.orchestrator.adapter.out.product.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import com.msa.commerce.orchestrator.domain.vo.ProductVerification;
+import com.msa.commerce.orchestrator.domain.vo.VerifiedProduct;
+
+public record ProductVerifyApiResponse(Boolean allAvailable, List<Result> results) {
+
+    public ProductVerification toDomain() {
+        List<VerifiedProduct> verifiedProducts = results != null
+            ? results.stream().map(Result::toDomain).toList()
+            : List.of();
+
+        return new ProductVerification(Boolean.TRUE.equals(allAvailable), verifiedProducts);
+    }
+
+    public record Result(
+        Long productId,
+        String sku,
+        String name,
+        Boolean available,
+        Integer availableStock,
+        BigDecimal currentPrice,
+        String unavailableReason
+    ) {
+
+        VerifiedProduct toDomain() {
+            return new VerifiedProduct(
+                productId,
+                sku,
+                name,
+                Boolean.TRUE.equals(available),
+                currentPrice,
+                availableStock,
+                unavailableReason
+            );
+        }
+
+    }
+
+}

--- a/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/application/port/in/CreateOrderCommand.java
+++ b/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/application/port/in/CreateOrderCommand.java
@@ -33,17 +33,11 @@ public class CreateOrderCommand {
 
         private Long productId;
 
-        private String productName;
-
-        private String productSku;
-
         private Long productVariantId;
 
         private String variantName;
 
         private Integer quantity;
-
-        private java.math.BigDecimal unitPrice;
 
     }
 

--- a/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/application/port/out/ProductPort.java
+++ b/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/application/port/out/ProductPort.java
@@ -1,0 +1,12 @@
+package com.msa.commerce.orchestrator.application.port.out;
+
+import java.util.List;
+
+import com.msa.commerce.orchestrator.domain.vo.ProductVerification;
+import com.msa.commerce.orchestrator.domain.vo.ProductVerificationItem;
+
+public interface ProductPort {
+
+    ProductVerification verify(List<ProductVerificationItem> items);
+
+}

--- a/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/application/service/CreateOrderService.java
+++ b/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/application/service/CreateOrderService.java
@@ -1,6 +1,8 @@
 package com.msa.commerce.orchestrator.application.service;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,8 +11,12 @@ import com.msa.commerce.orchestrator.application.port.in.CreateOrderCommand;
 import com.msa.commerce.orchestrator.application.port.in.CreateOrderUseCase;
 import com.msa.commerce.orchestrator.application.port.out.OrderEventPublisher;
 import com.msa.commerce.orchestrator.application.port.out.OrderRepository;
+import com.msa.commerce.orchestrator.application.port.out.ProductPort;
 import com.msa.commerce.orchestrator.domain.Order;
 import com.msa.commerce.orchestrator.domain.OrderItem;
+import com.msa.commerce.orchestrator.domain.vo.ProductVerification;
+import com.msa.commerce.orchestrator.domain.vo.ProductVerificationItem;
+import com.msa.commerce.orchestrator.domain.vo.VerifiedProduct;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,34 +30,60 @@ public class CreateOrderService implements CreateOrderUseCase {
 
     private final OrderEventPublisher orderEventPublisher;
 
+    private final ProductPort productPort;
+
     @Override
     @Transactional
     public UUID createOrder(CreateOrderCommand command) {
-        Order order = Order.create(
+        ProductVerification verification = verifyProducts(command);
+
+        Order order = newOrder(command);
+        command.getOrderItems()
+            .forEach(item -> order.addOrderItem(toOrderItem(item, verification.find(item.getProductId()))));
+
+        Order savedOrder = orderRepository.save(order);
+        orderEventPublisher.publishOrderCreated(savedOrder);
+
+        return savedOrder.getOrderId();
+    }
+
+    private ProductVerification verifyProducts(CreateOrderCommand command) {
+        List<ProductVerificationItem> items = command.getOrderItems().stream()
+            .map(item -> new ProductVerificationItem(item.getProductId(), item.getQuantity()))
+            .toList();
+
+        ProductVerification verification = productPort.verify(items);
+        if (!verification.allAvailable()) {
+            throw new ProductUnavailableException(describeUnavailable(verification));
+        }
+        return verification;
+    }
+
+    private String describeUnavailable(ProductVerification verification) {
+        return verification.unavailableProducts().stream()
+            .map(product -> "productId=%d(%s)".formatted(product.productId(), product.unavailableReason()))
+            .collect(Collectors.joining(", ", "Products are not available for order: ", ""));
+    }
+
+    private Order newOrder(CreateOrderCommand command) {
+        return Order.create(
             command.getOrderNumber(),
             command.getCustomerId(),
             command.getShippingAddress(),
             command.getSourceChannel()
         );
+    }
 
-        command.getOrderItems().forEach(itemCommand -> {
-            OrderItem orderItem = OrderItem.create(
-                itemCommand.getProductId(),
-                itemCommand.getProductName(),
-                itemCommand.getProductSku(),
-                itemCommand.getProductVariantId(),
-                itemCommand.getVariantName(),
-                itemCommand.getQuantity(),
-                itemCommand.getUnitPrice()
-            );
-            order.addOrderItem(orderItem);
-        });
-
-        Order savedOrder = orderRepository.save(order);
-
-        orderEventPublisher.publishOrderCreated(savedOrder);
-
-        return savedOrder.getOrderId();
+    private OrderItem toOrderItem(CreateOrderCommand.OrderItemCommand item, VerifiedProduct product) {
+        return OrderItem.create(
+            product.productId(),
+            product.name(),
+            product.sku(),
+            item.getProductVariantId(),
+            item.getVariantName(),
+            item.getQuantity(),
+            product.currentPrice()
+        );
     }
 
 }

--- a/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/application/service/ProductUnavailableException.java
+++ b/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/application/service/ProductUnavailableException.java
@@ -1,0 +1,13 @@
+package com.msa.commerce.orchestrator.application.service;
+
+import com.msa.commerce.common.exception.ValidationException;
+
+public class ProductUnavailableException extends ValidationException {
+
+    private static final String ERROR_CODE = "PRODUCT_UNAVAILABLE";
+
+    public ProductUnavailableException(String message) {
+        super(message, ERROR_CODE);
+    }
+
+}

--- a/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/config/RestClientConfig.java
+++ b/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/config/RestClientConfig.java
@@ -1,0 +1,22 @@
+package com.msa.commerce.orchestrator.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+import com.msa.commerce.common.config.RestClientFactory;
+import com.msa.commerce.common.config.RestClientProperties;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient productRestClient(
+        @Value("${external.product-service.url}") String baseUrl,
+        @Value("${external.product-service.timeout-millis:3000}") long timeoutMillis) {
+
+        return RestClientFactory.create(RestClientProperties.of(baseUrl, timeoutMillis));
+    }
+
+}

--- a/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/domain/vo/ProductVerification.java
+++ b/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/domain/vo/ProductVerification.java
@@ -1,0 +1,24 @@
+package com.msa.commerce.orchestrator.domain.vo;
+
+import java.util.List;
+
+public record ProductVerification(boolean allAvailable, List<VerifiedProduct> results) {
+
+    public ProductVerification {
+        results = results != null ? List.copyOf(results) : List.of();
+    }
+
+    public VerifiedProduct find(Long productId) {
+        return results.stream()
+            .filter(result -> result.productId().equals(productId))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("Verification result is missing for productId: " + productId));
+    }
+
+    public List<VerifiedProduct> unavailableProducts() {
+        return results.stream()
+            .filter(result -> !result.available())
+            .toList();
+    }
+
+}

--- a/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/domain/vo/ProductVerificationItem.java
+++ b/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/domain/vo/ProductVerificationItem.java
@@ -1,0 +1,15 @@
+package com.msa.commerce.orchestrator.domain.vo;
+
+import java.util.Objects;
+
+public record ProductVerificationItem(Long productId, Integer quantity) {
+
+    public ProductVerificationItem {
+        Objects.requireNonNull(productId, "Product ID cannot be null");
+        Objects.requireNonNull(quantity, "Quantity cannot be null");
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("Quantity must be positive");
+        }
+    }
+
+}

--- a/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/domain/vo/VerifiedProduct.java
+++ b/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/domain/vo/VerifiedProduct.java
@@ -1,0 +1,32 @@
+package com.msa.commerce.orchestrator.domain.vo;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public record VerifiedProduct(
+    Long productId,
+    String sku,
+    String name,
+    boolean available,
+    BigDecimal currentPrice,
+    Integer availableStock,
+    String unavailableReason
+) {
+
+    public VerifiedProduct {
+        Objects.requireNonNull(productId, "Product ID cannot be null");
+        if (available) {
+            requireOrderableAttributes(sku, name, currentPrice);
+        }
+    }
+
+    private static void requireOrderableAttributes(String sku, String name, BigDecimal currentPrice) {
+        Objects.requireNonNull(sku, "SKU cannot be null for an available product");
+        Objects.requireNonNull(name, "Product name cannot be null for an available product");
+        Objects.requireNonNull(currentPrice, "Current price cannot be null for an available product");
+        if (currentPrice.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("Current price must be greater than zero");
+        }
+    }
+
+}

--- a/order-orchestrator/src/main/resources/application-docker.yml
+++ b/order-orchestrator/src/main/resources/application-docker.yml
@@ -10,3 +10,7 @@ spring:
   kafka:
     bootstrap-servers: kafka:9092
 
+external:
+  product-service:
+    url: http://monolith:8080
+

--- a/order-orchestrator/src/main/resources/application.yml
+++ b/order-orchestrator/src/main/resources/application.yml
@@ -84,6 +84,11 @@ management:
     tags:
       application: ${spring.application.name}
 
+external:
+  product-service:
+    url: http://localhost:8080
+    timeout-millis: 3000
+
 logging:
   level:
     com.msa.commerce: DEBUG

--- a/order-orchestrator/src/test/java/com/msa/commerce/orchestrator/adapter/out/product/ProductVerifyAdapterTest.java
+++ b/order-orchestrator/src/test/java/com/msa/commerce/orchestrator/adapter/out/product/ProductVerifyAdapterTest.java
@@ -1,0 +1,119 @@
+package com.msa.commerce.orchestrator.adapter.out.product;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import com.msa.commerce.orchestrator.domain.vo.ProductVerification;
+import com.msa.commerce.orchestrator.domain.vo.ProductVerificationItem;
+import com.msa.commerce.orchestrator.domain.vo.VerifiedProduct;
+
+@DisplayName("ProductVerifyAdapter 단위 테스트")
+class ProductVerifyAdapterTest {
+
+    private static final String VERIFY_URL = "http://product-service/api/v1/products/verify";
+
+    private MockRestServiceServer server;
+
+    private ProductVerifyAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder().baseUrl("http://product-service");
+        server = MockRestServiceServer.bindTo(builder).build();
+        adapter = new ProductVerifyAdapter(builder.build());
+    }
+
+    @Test
+    @DisplayName("검증 응답을 도메인 객체로 변환한다")
+    void verify_MapsResponseToDomain() {
+        server.expect(requestTo(VERIFY_URL))
+            .andExpect(method(org.springframework.http.HttpMethod.POST))
+            .andExpect(jsonPath("$.items[0].productId").value(101))
+            .andExpect(jsonPath("$.items[0].quantity").value(2))
+            .andRespond(withSuccess("""
+                {
+                  "allAvailable": true,
+                  "results": [
+                    {
+                      "productId": 101,
+                      "sku": "SKU-101",
+                      "name": "무선 키보드",
+                      "available": true,
+                      "availableStock": 50,
+                      "currentPrice": 25000,
+                      "unavailableReason": null
+                    }
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        ProductVerification verification = adapter.verify(List.of(new ProductVerificationItem(101L, 2)));
+
+        assertThat(verification.allAvailable()).isTrue();
+        VerifiedProduct product = verification.find(101L);
+        assertThat(product.name()).isEqualTo("무선 키보드");
+        assertThat(product.sku()).isEqualTo("SKU-101");
+        assertThat(product.currentPrice()).isEqualByComparingTo("25000");
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("구매 불가 상품은 사유와 함께 매핑된다")
+    void verify_MapsUnavailableProduct() {
+        server.expect(requestTo(VERIFY_URL))
+            .andRespond(withSuccess("""
+                {
+                  "allAvailable": false,
+                  "results": [
+                    {
+                      "productId": 101,
+                      "sku": "SKU-101",
+                      "name": "무선 키보드",
+                      "available": false,
+                      "availableStock": 0,
+                      "currentPrice": 25000,
+                      "unavailableReason": "재고 부족"
+                    }
+                  ]
+                }
+                """, MediaType.APPLICATION_JSON));
+
+        ProductVerification verification = adapter.verify(List.of(new ProductVerificationItem(101L, 2)));
+
+        assertThat(verification.allAvailable()).isFalse();
+        assertThat(verification.unavailableProducts())
+            .singleElement()
+            .satisfies(product -> assertThat(product.unavailableReason()).isEqualTo("재고 부족"));
+    }
+
+    @Test
+    @DisplayName("Product Service 장애 시 ProductServiceException으로 전환된다")
+    void verify_WrapsServerError() {
+        server.expect(requestTo(VERIFY_URL)).andRespond(withServerError());
+
+        assertThatThrownBy(() -> adapter.verify(List.of(new ProductVerificationItem(101L, 2))))
+            .isInstanceOf(ProductServiceException.class)
+            .hasMessageContaining("Failed to verify products");
+    }
+
+    @Test
+    @DisplayName("응답 본문이 비어 있으면 ProductServiceException을 던진다")
+    void verify_ThrowsOnEmptyBody() {
+        server.expect(requestTo(VERIFY_URL)).andRespond(withSuccess());
+
+        assertThatThrownBy(() -> adapter.verify(List.of(new ProductVerificationItem(101L, 2))))
+            .isInstanceOf(ProductServiceException.class)
+            .hasMessageContaining("empty verification response");
+    }
+
+}

--- a/order-orchestrator/src/test/java/com/msa/commerce/orchestrator/application/service/CreateOrderServiceTest.java
+++ b/order-orchestrator/src/test/java/com/msa/commerce/orchestrator/application/service/CreateOrderServiceTest.java
@@ -1,0 +1,144 @@
+package com.msa.commerce.orchestrator.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.msa.commerce.orchestrator.application.port.in.CreateOrderCommand;
+import com.msa.commerce.orchestrator.application.port.out.OrderEventPublisher;
+import com.msa.commerce.orchestrator.application.port.out.OrderRepository;
+import com.msa.commerce.orchestrator.application.port.out.ProductPort;
+import com.msa.commerce.orchestrator.domain.Order;
+import com.msa.commerce.orchestrator.domain.OrderItem;
+import com.msa.commerce.orchestrator.domain.vo.ProductVerification;
+import com.msa.commerce.orchestrator.domain.vo.ProductVerificationItem;
+import com.msa.commerce.orchestrator.domain.vo.VerifiedProduct;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CreateOrderService 단위 테스트")
+class CreateOrderServiceTest {
+
+    private static final Long PRODUCT_ID = 101L;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private OrderEventPublisher orderEventPublisher;
+
+    @Mock
+    private ProductPort productPort;
+
+    @InjectMocks
+    private CreateOrderService createOrderService;
+
+    @Test
+    @DisplayName("주문 항목 정보는 클라이언트 입력이 아닌 Product Service 검증 결과로 확정된다")
+    void createOrder_UsesVerifiedProductAttributes() {
+        // Given
+        when(productPort.verify(anyList()))
+            .thenReturn(verification(true, availableProduct(new BigDecimal("25000"))));
+        when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // When
+        createOrderService.createOrder(command(2));
+
+        // Then
+        ArgumentCaptor<Order> captor = ArgumentCaptor.forClass(Order.class);
+        verify(orderRepository).save(captor.capture());
+
+        OrderItem savedItem = captor.getValue().getOrderItems().getFirst();
+        assertThat(savedItem.getProductName()).isEqualTo("검증된 상품명");
+        assertThat(savedItem.getProductSku()).isEqualTo("SKU-VERIFIED");
+        assertThat(savedItem.getUnitPrice()).isEqualByComparingTo("25000");
+    }
+
+    @Test
+    @DisplayName("주문 수량이 그대로 검증 요청으로 전달된다")
+    void createOrder_PassesRequestedQuantityToVerification() {
+        // Given
+        when(productPort.verify(anyList()))
+            .thenReturn(verification(true, availableProduct(new BigDecimal("25000"))));
+        when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // When
+        createOrderService.createOrder(command(3));
+
+        // Then
+        ArgumentCaptor<List<ProductVerificationItem>> captor = ArgumentCaptor.captor();
+        verify(productPort).verify(captor.capture());
+
+        assertThat(captor.getValue())
+            .containsExactly(new ProductVerificationItem(PRODUCT_ID, 3));
+    }
+
+    @Test
+    @DisplayName("구매 불가 상품이 포함되면 주문이 생성되지 않는다")
+    void createOrder_ThrowsWhenProductUnavailable() {
+        // Given
+        VerifiedProduct unavailable = new VerifiedProduct(
+            PRODUCT_ID, null, null, false, null, 0, "재고 부족");
+        when(productPort.verify(anyList())).thenReturn(verification(false, unavailable));
+
+        // When & Then
+        assertThatThrownBy(() -> createOrderService.createOrder(command(2)))
+            .isInstanceOf(ProductUnavailableException.class)
+            .hasMessageContaining("productId=101")
+            .hasMessageContaining("재고 부족");
+
+        verify(orderRepository, never()).save(any(Order.class));
+        verify(orderEventPublisher, never()).publishOrderCreated(any(Order.class));
+    }
+
+    @Test
+    @DisplayName("주문 저장 후 주문 생성 이벤트를 발행한다")
+    void createOrder_PublishesOrderCreatedEvent() {
+        // Given
+        when(productPort.verify(anyList()))
+            .thenReturn(verification(true, availableProduct(new BigDecimal("25000"))));
+        when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // When
+        UUID orderId = createOrderService.createOrder(command(2));
+
+        // Then
+        assertThat(orderId).isNotNull();
+        verify(orderEventPublisher).publishOrderCreated(any(Order.class));
+    }
+
+    private CreateOrderCommand command(int quantity) {
+        return CreateOrderCommand.builder()
+            .orderNumber("ORD-20260726-0001")
+            .customerId(1L)
+            .shippingAddress(Map.of("zipCode", "06236", "addressLine1", "서울시 강남구"))
+            .sourceChannel("WEB")
+            .orderItems(List.of(CreateOrderCommand.OrderItemCommand.builder()
+                .productId(PRODUCT_ID)
+                .quantity(quantity)
+                .build()))
+            .build();
+    }
+
+    private ProductVerification verification(boolean allAvailable, VerifiedProduct product) {
+        return new ProductVerification(allAvailable, List.of(product));
+    }
+
+    private VerifiedProduct availableProduct(BigDecimal currentPrice) {
+        return new VerifiedProduct(
+            PRODUCT_ID, "SKU-VERIFIED", "검증된 상품명", true, currentPrice, 50, null);
+    }
+
+}


### PR DESCRIPTION
## 📋 PR 요약

주문 생성 시 Product Service의 검증 API(`POST /api/v1/products/verify`)를 호출하여 상품 구매 가능 여부를 확인하고, 주문 항목의 상품명/SKU/단가를 클라이언트 입력이 아닌 **검증 응답 값으로 확정**합니다.

> PR #66을 대체합니다. 주문 생성 API 자체는 PR #70(#46)으로 이미 머지되어, 본 PR은 #66의 고유 가치였던 Product 연동만 develop 최신 기준으로 재구현했습니다.

### 🔗 관련 이슈

- Closes #59
- Related to #26 (Product 검증 API — 본 PR의 소비자 측 구현)

### 📝 변경 사항

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 문서 업데이트
- [x] 테스트 코드 추가/수정

### 🛠️ 기술적 변경 사항

- **새로 추가된 파일**:
  - `common` — `RestClientFactory`, `RestClientProperties`, `ExternalServiceException`
  - `order-orchestrator` — `ProductPort`(out port), `ProductVerifyAdapter` + API DTO 2종, `domain/vo`(`ProductVerification`, `VerifiedProduct`, `ProductVerificationItem`), `ProductUnavailableException`, `ProductServiceException`, `RestClientConfig`
- **수정된 파일**:
  - `CreateOrderService` — 주문 생성 전 배치 검증 수행, 검증 값으로 OrderItem 구성
  - `CreateOrderRequest` / `CreateOrderCommand` — `productName`/`productSku`/`unitPrice` 필드 제거
  - `GlobalExceptionHandler` — `ExternalServiceException` → 503 매핑 추가
  - `application.yml` / `application-docker.yml` — `external.product-service` 설정 추가
  - `order-orchestrator-openapi.yml` — `POST /api/v1/orders` 스펙 신규 작성(기존 누락), `ErrorResponse` 스키마를 실제 구현과 일치하도록 수정
- **주요 로직 변경**:
  - 상품별 단건 조회(N회) 대신 verify API 배치 검증(1회) 사용
  - 구매 불가 상품 포함 시 `ProductUnavailableException`(400)으로 주문 거부
  - Product Service 장애 시 `ProductServiceException`(503)으로 구분 응답

### 🔒 보안

- 주문 금액 위변조 차단: 단가를 서버 측 검증 값으로만 확정하므로 클라이언트가 가격을 조작할 수 없습니다.

### 🧪 테스트

- [x] 단위 테스트 통과 (신규 8건 포함, 139/143)
- [ ] 통합 테스트 — Kafka 통합 테스트 4건은 Testcontainers 1.21.3 ↔ Docker 29.6.2 비호환으로 로컬 실행 불가 (본 PR 변경과 무관, PR #70 시점부터 존재)

**테스트 방법:**

1. `./gradlew :order-orchestrator:test --tests "*CreateOrderServiceTest" --tests "*ProductVerifyAdapterTest"`
2. monolith(8080) 기동 후 `POST http://localhost:8081/api/v1/orders` 호출 — 요청 본문에 상품명/단가 없이 `productId`/`quantity`만 전달
3. 존재하지 않는 productId로 주문 시 400 + `PRODUCT_UNAVAILABLE` 확인

### 📊 성능 영향

- [x] 성능에 영향 없음 (상품 N개 주문 시 HTTP 1회 호출)

### 📖 문서 업데이트

- [x] API 문서 업데이트 완료 — `POST /api/v1/orders` 스펙 추가, Redocly lint 통과(경고 36→29)
