### PR TITLE
feat(#48): Materialized View Worker 구현

### DIFF
--- a/materialized-view/build.gradle.kts
+++ b/materialized-view/build.gradle.kts
@@ -5,6 +5,10 @@ dependencies {
     // Redis dependency moved to common module
     implementation(BuildDependencies.getSpringKafka())
 
+    // MapStruct
+    implementation(BuildDependencies.getMapstruct())
+    annotationProcessor(BuildDependencies.getMapstructProcessor())
+
     // Database connector
     runtimeOnly(BuildDependencies.getMysqlConnectorRuntime())
 

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/in/kafka/KafkaConsumerConfig.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/in/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,78 @@
+package com.msa.commerce.materializedview.adapter.in.kafka;
+
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.util.backoff.ExponentialBackOff;
+
+import com.msa.commerce.materializedview.adapter.in.kafka.dto.OrderCreatedEvent;
+import com.msa.commerce.materializedview.adapter.in.kafka.dto.OrderUpdatedEvent;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class KafkaConsumerConfig {
+
+    private static final String TRUSTED_PACKAGE = "com.msa.commerce.materializedview.adapter.in.kafka.dto";
+
+    private final KafkaProperties kafkaProperties;
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, OrderCreatedEvent> orderCreatedListenerContainerFactory(
+        CommonErrorHandler kafkaViewErrorHandler) {
+        return listenerContainerFactory(OrderCreatedEvent.class, kafkaViewErrorHandler);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, OrderUpdatedEvent> orderUpdatedListenerContainerFactory(
+        CommonErrorHandler kafkaViewErrorHandler) {
+        return listenerContainerFactory(OrderUpdatedEvent.class, kafkaViewErrorHandler);
+    }
+
+    // 재시도 소진 시 DLT로 이관해 이벤트 유실 없이 장애를 격리한다.
+    @Bean
+    public CommonErrorHandler kafkaViewErrorHandler(KafkaTemplate<Object, Object> kafkaTemplate) {
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate,
+            (record, ex) -> new TopicPartition(OrderEventTopics.DEAD_LETTER_QUEUE, -1));
+        return new DefaultErrorHandler(recoverer, retryBackOff());
+    }
+
+    private ExponentialBackOff retryBackOff() {
+        ExponentialBackOff backOff = new ExponentialBackOff(1000L, 2.0);
+        backOff.setMaxAttempts(3);
+        return backOff;
+    }
+
+    private <T> ConcurrentKafkaListenerContainerFactory<String, T> listenerContainerFactory(
+        Class<T> eventType, CommonErrorHandler errorHandler) {
+        ConcurrentKafkaListenerContainerFactory<String, T> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(consumerProps(eventType)));
+        factory.setCommonErrorHandler(errorHandler);
+        return factory;
+    }
+
+    // 발행 측 클래스명이 담긴 타입 헤더를 무시하고, 토픽별 소비자 계약 타입으로 역직렬화한다.
+    private Map<String, Object> consumerProps(Class<?> eventType) {
+        Map<String, Object> props = kafkaProperties.buildConsumerProperties(null);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, eventType.getName());
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, TRUSTED_PACKAGE);
+        return props;
+    }
+
+}

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/in/kafka/OrderEventConsumer.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/in/kafka/OrderEventConsumer.java
@@ -1,0 +1,43 @@
+package com.msa.commerce.materializedview.adapter.in.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.msa.commerce.materializedview.adapter.in.kafka.dto.OrderCreatedEvent;
+import com.msa.commerce.materializedview.adapter.in.kafka.dto.OrderUpdatedEvent;
+import com.msa.commerce.materializedview.adapter.in.kafka.mapper.OrderViewMapper;
+import com.msa.commerce.materializedview.application.port.in.UpdateOrderViewUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderEventConsumer {
+
+    private final UpdateOrderViewUseCase updateOrderViewUseCase;
+
+    private final OrderViewMapper orderViewMapper;
+
+    @KafkaListener(
+        topics = OrderEventTopics.ORDER_CREATED,
+        containerFactory = "orderCreatedListenerContainerFactory"
+    )
+    public void onOrderCreated(OrderCreatedEvent event) {
+        log.debug("Received order.created: orderId={}, eventId={}",
+            event.orderId(), event.metadata().eventId());
+        updateOrderViewUseCase.applyOrderCreated(orderViewMapper.toView(event));
+    }
+
+    @KafkaListener(
+        topics = OrderEventTopics.ORDER_UPDATED,
+        containerFactory = "orderUpdatedListenerContainerFactory"
+    )
+    public void onOrderUpdated(OrderUpdatedEvent event) {
+        log.debug("Received order.updated: orderId={}, {} -> {}",
+            event.orderId(), event.previousStatus(), event.currentStatus());
+        updateOrderViewUseCase.applyStatusChanged(orderViewMapper.toView(event));
+    }
+
+}

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/in/kafka/OrderEventTopics.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/in/kafka/OrderEventTopics.java
@@ -1,0 +1,14 @@
+package com.msa.commerce.materializedview.adapter.in.kafka;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class OrderEventTopics {
+
+    public static final String ORDER_CREATED = "order.created";
+
+    public static final String ORDER_UPDATED = "order.updated";
+
+    public static final String DEAD_LETTER_QUEUE = "dead.letter.queue";
+
+}

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/in/kafka/dto/EventMetadata.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/in/kafka/dto/EventMetadata.java
@@ -1,0 +1,17 @@
+package com.msa.commerce.materializedview.adapter.in.kafka.dto;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record EventMetadata(
+    String eventId,
+    String correlationId,
+    LocalDateTime timestamp,
+    String eventType,
+    String source,
+    Integer version
+) {
+
+}

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/in/kafka/dto/OrderCreatedEvent.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/in/kafka/dto/OrderCreatedEvent.java
@@ -1,0 +1,36 @@
+package com.msa.commerce.materializedview.adapter.in.kafka.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+// order-orchestrator가 발행하는 order.created 이벤트의 소비자 측 계약.
+// 뷰 갱신에 불필요한 필드(shippingAddress 등)는 수신하지 않는다.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record OrderCreatedEvent(
+    EventMetadata metadata,
+    UUID orderId,
+    String orderNumber,
+    Long customerId,
+    BigDecimal totalAmount,
+    String currency,
+    List<OrderItemData> orderItems,
+    String sourceChannel,
+    LocalDateTime orderDate
+) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OrderItemData(
+        Long productId,
+        String productName,
+        Integer quantity,
+        BigDecimal unitPrice,
+        BigDecimal totalPrice
+    ) {
+
+    }
+
+}

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/in/kafka/dto/OrderUpdatedEvent.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/in/kafka/dto/OrderUpdatedEvent.java
@@ -1,0 +1,21 @@
+package com.msa.commerce.materializedview.adapter.in.kafka.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+// 상태는 발행 측 enum이 추가되어도 역직렬화가 깨지지 않도록 String으로 수신한다.
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record OrderUpdatedEvent(
+    EventMetadata metadata,
+    UUID orderId,
+    String orderNumber,
+    String previousStatus,
+    String currentStatus,
+    Long customerId,
+    LocalDateTime statusChangedAt,
+    String reason
+) {
+
+}

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/in/kafka/mapper/OrderViewMapper.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/in/kafka/mapper/OrderViewMapper.java
@@ -1,0 +1,20 @@
+package com.msa.commerce.materializedview.adapter.in.kafka.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import com.msa.commerce.materializedview.adapter.in.kafka.dto.OrderCreatedEvent;
+import com.msa.commerce.materializedview.adapter.in.kafka.dto.OrderUpdatedEvent;
+import com.msa.commerce.materializedview.domain.OrderCreatedView;
+import com.msa.commerce.materializedview.domain.OrderStatusChangedView;
+
+@Mapper(componentModel = "spring")
+public interface OrderViewMapper {
+
+    @Mapping(source = "metadata.eventId", target = "eventId")
+    OrderCreatedView toView(OrderCreatedEvent event);
+
+    @Mapping(source = "metadata.eventId", target = "eventId")
+    OrderStatusChangedView toView(OrderUpdatedEvent event);
+
+}

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/out/idempotency/RedisProcessedEventAdapter.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/out/idempotency/RedisProcessedEventAdapter.java
@@ -1,0 +1,34 @@
+package com.msa.commerce.materializedview.adapter.out.idempotency;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.msa.commerce.materializedview.application.port.out.ProcessedEventPort;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisProcessedEventAdapter implements ProcessedEventPort {
+
+    private static final String KEY_PREFIX = "mv:processed-event:";
+
+    private static final Duration RETENTION = Duration.ofHours(24);
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public boolean markProcessed(String eventId) {
+        Boolean marked = redisTemplate.opsForValue()
+            .setIfAbsent(KEY_PREFIX + eventId, "1", RETENTION);
+        return Boolean.TRUE.equals(marked);
+    }
+
+    @Override
+    public void unmark(String eventId) {
+        redisTemplate.delete(KEY_PREFIX + eventId);
+    }
+
+}

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/out/persistence/OrderViewRepositoryAdapter.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/adapter/out/persistence/OrderViewRepositoryAdapter.java
@@ -1,0 +1,124 @@
+package com.msa.commerce.materializedview.adapter.out.persistence;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.msa.commerce.materializedview.application.port.out.OrderViewRepository;
+import com.msa.commerce.materializedview.domain.OrderCreatedView;
+import com.msa.commerce.materializedview.domain.OrderStatusChangedView;
+
+import lombok.RequiredArgsConstructor;
+
+// 모든 갱신은 DB 원자적 upsert(ON DUPLICATE KEY)로 수행해 동시 소비 시 레이스를 제거한다.
+// LIFETIME 행은 unique key의 NULL 중복 문제를 피하기 위해 sentinel 날짜(1970-01-01)를 사용한다.
+@Repository
+@RequiredArgsConstructor
+public class OrderViewRepositoryAdapter implements OrderViewRepository {
+
+    private static final String UPSERT_PRODUCT_SALES = """
+        INSERT INTO product_sales_summary
+            (product_id, product_sku, product_name, total_quantity_sold, total_revenue,
+             average_selling_price, total_orders, last_sale_date, first_sale_date,
+             summary_period, period_start_date)
+        VALUES (?, '', ?, ?, ?, ?, 1, ?, ?, 'LIFETIME', '1970-01-01') AS new
+        ON DUPLICATE KEY UPDATE
+            product_name = new.product_name,
+            total_quantity_sold = product_sales_summary.total_quantity_sold + new.total_quantity_sold,
+            total_revenue = product_sales_summary.total_revenue + new.total_revenue,
+            total_orders = product_sales_summary.total_orders + 1,
+            average_selling_price = product_sales_summary.total_revenue
+                / NULLIF(product_sales_summary.total_quantity_sold, 0),
+            last_sale_date = GREATEST(product_sales_summary.last_sale_date, new.last_sale_date),
+            first_sale_date = LEAST(product_sales_summary.first_sale_date, new.first_sale_date)
+        """;
+
+    private static final String UPSERT_USER_ORDER_CREATED = """
+        INSERT INTO user_order_summary
+            (user_id, total_orders, pending_orders, total_spent, average_order_value,
+             lifetime_value, first_order_date, last_order_date, summary_period, period_start_date)
+        VALUES (?, 1, 1, ?, ?, ?, ?, ?, 'LIFETIME', '1970-01-01') AS new
+        ON DUPLICATE KEY UPDATE
+            total_orders = user_order_summary.total_orders + 1,
+            pending_orders = user_order_summary.pending_orders + 1,
+            total_spent = user_order_summary.total_spent + new.total_spent,
+            lifetime_value = user_order_summary.lifetime_value + new.total_spent,
+            average_order_value = user_order_summary.total_spent / user_order_summary.total_orders,
+            first_order_date = LEAST(user_order_summary.first_order_date, new.first_order_date),
+            last_order_date = GREATEST(user_order_summary.last_order_date, new.last_order_date)
+        """;
+
+    private static final String UPDATE_USER_ORDER_STATUS = """
+        UPDATE user_order_summary
+        SET pending_orders = GREATEST(CAST(pending_orders AS SIGNED) + ?, 0),
+            completed_orders = GREATEST(CAST(completed_orders AS SIGNED) + ?, 0),
+            cancelled_orders = GREATEST(CAST(cancelled_orders AS SIGNED) + ?, 0)
+        WHERE user_id = ? AND summary_period = 'LIFETIME' AND period_start_date = '1970-01-01'
+        """;
+
+    private static final String UPSERT_DAILY_METRICS_CREATED = """
+        INSERT INTO daily_business_metrics (business_date, total_orders, total_revenue, products_sold)
+        VALUES (?, 1, ?, ?) AS new
+        ON DUPLICATE KEY UPDATE
+            total_orders = daily_business_metrics.total_orders + 1,
+            total_revenue = daily_business_metrics.total_revenue + new.total_revenue,
+            products_sold = daily_business_metrics.products_sold + new.products_sold,
+            average_order_value = daily_business_metrics.total_revenue / daily_business_metrics.total_orders
+        """;
+
+    private static final String UPSERT_DAILY_METRICS_STATUS = """
+        INSERT INTO daily_business_metrics (business_date, completed_orders, cancelled_orders)
+        VALUES (?, GREATEST(?, 0), GREATEST(?, 0))
+        ON DUPLICATE KEY UPDATE
+            completed_orders = GREATEST(CAST(completed_orders AS SIGNED) + ?, 0),
+            cancelled_orders = GREATEST(CAST(cancelled_orders AS SIGNED) + ?, 0)
+        """;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    @Transactional
+    public void applyOrderCreated(OrderCreatedView view) {
+        LocalDate orderDate = view.orderDate().toLocalDate();
+        view.orderItems().forEach(item -> upsertProductSales(item, orderDate));
+        upsertUserOrderCreated(view, orderDate);
+        jdbcTemplate.update(UPSERT_DAILY_METRICS_CREATED, orderDate, view.totalAmount(), view.totalQuantity());
+    }
+
+    @Override
+    @Transactional
+    public void applyStatusChanged(OrderStatusChangedView view) {
+        if (!view.hasCategoryChanged()) {
+            return;
+        }
+        jdbcTemplate.update(UPDATE_USER_ORDER_STATUS,
+            view.pendingDelta(), view.completedDelta(), view.cancelledDelta(), view.customerId());
+        jdbcTemplate.update(UPSERT_DAILY_METRICS_STATUS,
+            view.statusChangedAt().toLocalDate(), view.completedDelta(), view.cancelledDelta(),
+            view.completedDelta(), view.cancelledDelta());
+    }
+
+    private void upsertProductSales(OrderCreatedView.OrderItemView item, LocalDate orderDate) {
+        jdbcTemplate.update(UPSERT_PRODUCT_SALES,
+            item.productId(), item.productName(), item.quantity(), item.totalPrice(),
+            averagePrice(item), orderDate, orderDate);
+    }
+
+    private void upsertUserOrderCreated(OrderCreatedView view, LocalDate orderDate) {
+        jdbcTemplate.update(UPSERT_USER_ORDER_CREATED,
+            view.customerId(), view.totalAmount(), view.totalAmount(), view.totalAmount(),
+            orderDate, orderDate);
+    }
+
+    private BigDecimal averagePrice(OrderCreatedView.OrderItemView item) {
+        if (item.quantity() == null || item.quantity() == 0) {
+            return BigDecimal.ZERO;
+        }
+        return item.totalPrice().divide(BigDecimal.valueOf(item.quantity()), 2, RoundingMode.HALF_UP);
+    }
+
+}

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/application/port/in/UpdateOrderViewUseCase.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/application/port/in/UpdateOrderViewUseCase.java
@@ -1,0 +1,12 @@
+package com.msa.commerce.materializedview.application.port.in;
+
+import com.msa.commerce.materializedview.domain.OrderCreatedView;
+import com.msa.commerce.materializedview.domain.OrderStatusChangedView;
+
+public interface UpdateOrderViewUseCase {
+
+    void applyOrderCreated(OrderCreatedView view);
+
+    void applyStatusChanged(OrderStatusChangedView view);
+
+}

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/application/port/out/OrderViewRepository.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/application/port/out/OrderViewRepository.java
@@ -1,0 +1,12 @@
+package com.msa.commerce.materializedview.application.port.out;
+
+import com.msa.commerce.materializedview.domain.OrderCreatedView;
+import com.msa.commerce.materializedview.domain.OrderStatusChangedView;
+
+public interface OrderViewRepository {
+
+    void applyOrderCreated(OrderCreatedView view);
+
+    void applyStatusChanged(OrderStatusChangedView view);
+
+}

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/application/port/out/ProcessedEventPort.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/application/port/out/ProcessedEventPort.java
@@ -1,0 +1,9 @@
+package com.msa.commerce.materializedview.application.port.out;
+
+public interface ProcessedEventPort {
+
+    boolean markProcessed(String eventId);
+
+    void unmark(String eventId);
+
+}

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/application/service/OrderViewService.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/application/service/OrderViewService.java
@@ -1,0 +1,47 @@
+package com.msa.commerce.materializedview.application.service;
+
+import org.springframework.stereotype.Service;
+
+import com.msa.commerce.materializedview.application.port.in.UpdateOrderViewUseCase;
+import com.msa.commerce.materializedview.application.port.out.OrderViewRepository;
+import com.msa.commerce.materializedview.application.port.out.ProcessedEventPort;
+import com.msa.commerce.materializedview.domain.OrderCreatedView;
+import com.msa.commerce.materializedview.domain.OrderStatusChangedView;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderViewService implements UpdateOrderViewUseCase {
+
+    private final ProcessedEventPort processedEventPort;
+
+    private final OrderViewRepository orderViewRepository;
+
+    @Override
+    public void applyOrderCreated(OrderCreatedView view) {
+        applyOnce(view.eventId(), () -> orderViewRepository.applyOrderCreated(view));
+    }
+
+    @Override
+    public void applyStatusChanged(OrderStatusChangedView view) {
+        applyOnce(view.eventId(), () -> orderViewRepository.applyStatusChanged(view));
+    }
+
+    // 뷰 갱신 실패 시 처리 마크를 되돌려 컨슈머 재시도가 유실 없이 동작하게 한다.
+    private void applyOnce(String eventId, Runnable action) {
+        if (!processedEventPort.markProcessed(eventId)) {
+            log.info("Skipping already processed event: eventId={}", eventId);
+            return;
+        }
+        try {
+            action.run();
+        } catch (RuntimeException e) {
+            processedEventPort.unmark(eventId);
+            throw e;
+        }
+    }
+
+}

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/domain/OrderCreatedView.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/domain/OrderCreatedView.java
@@ -1,0 +1,36 @@
+package com.msa.commerce.materializedview.domain;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderCreatedView(
+    String eventId,
+    UUID orderId,
+    Long customerId,
+    BigDecimal totalAmount,
+    LocalDateTime orderDate,
+    List<OrderItemView> orderItems
+) {
+
+    public OrderCreatedView {
+        orderItems = orderItems != null ? List.copyOf(orderItems) : List.of();
+    }
+
+    public int totalQuantity() {
+        return orderItems.stream()
+            .mapToInt(OrderItemView::quantity)
+            .sum();
+    }
+
+    public record OrderItemView(
+        Long productId,
+        String productName,
+        Integer quantity,
+        BigDecimal totalPrice
+    ) {
+
+    }
+
+}

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/domain/OrderStatusCategory.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/domain/OrderStatusCategory.java
@@ -1,0 +1,20 @@
+package com.msa.commerce.materializedview.domain;
+
+public enum OrderStatusCategory {
+
+    ACTIVE,
+    COMPLETED,
+    CANCELLED;
+
+    public static OrderStatusCategory from(String status) {
+        if (status == null) {
+            return ACTIVE;
+        }
+        return switch (status) {
+            case "DELIVERED" -> COMPLETED;
+            case "CANCELLED", "REFUNDED", "FAILED" -> CANCELLED;
+            default -> ACTIVE;
+        };
+    }
+
+}

--- a/materialized-view/src/main/java/com/msa/commerce/materializedview/domain/OrderStatusChangedView.java
+++ b/materialized-view/src/main/java/com/msa/commerce/materializedview/domain/OrderStatusChangedView.java
@@ -1,0 +1,43 @@
+package com.msa.commerce.materializedview.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record OrderStatusChangedView(
+    String eventId,
+    UUID orderId,
+    Long customerId,
+    String previousStatus,
+    String currentStatus,
+    LocalDateTime statusChangedAt
+) {
+
+    public boolean hasCategoryChanged() {
+        return previousCategory() != currentCategory();
+    }
+
+    public int pendingDelta() {
+        return deltaOf(OrderStatusCategory.ACTIVE);
+    }
+
+    public int completedDelta() {
+        return deltaOf(OrderStatusCategory.COMPLETED);
+    }
+
+    public int cancelledDelta() {
+        return deltaOf(OrderStatusCategory.CANCELLED);
+    }
+
+    private int deltaOf(OrderStatusCategory category) {
+        return (currentCategory() == category ? 1 : 0) - (previousCategory() == category ? 1 : 0);
+    }
+
+    private OrderStatusCategory previousCategory() {
+        return OrderStatusCategory.from(previousStatus);
+    }
+
+    private OrderStatusCategory currentCategory() {
+        return OrderStatusCategory.from(currentStatus);
+    }
+
+}

--- a/materialized-view/src/main/resources/application-docker.yml
+++ b/materialized-view/src/main/resources/application-docker.yml
@@ -4,7 +4,7 @@ spring:
     activate:
       on-profile: docker
   datasource:
-    url: jdbc:mysql://mysql:3306/materialized_view_db
+    url: jdbc:mysql://mysql:3306/db_materialized_view
     username: root
     password: root
   data:

--- a/materialized-view/src/main/resources/application.yml
+++ b/materialized-view/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: materialized-view
 
   datasource:
-    url: jdbc:mysql://localhost:3306/materialized_view_db
+    url: jdbc:mysql://localhost:3306/db_materialized_view
     username: app_rw
     password: 1q2w3e4r!
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -21,17 +21,17 @@ spring:
 
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
 
   kafka:
     bootstrap-servers: localhost:9092
     consumer:
       group-id: materialized-view-group
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
-      properties:
-        spring.json.trusted.packages: "com.msa.commerce.common.events"
+      auto-offset-reset: earliest
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
 
 logging:
   level:

--- a/materialized-view/src/test/java/com/msa/commerce/materializedview/adapter/in/kafka/KafkaConsumerConfigTest.java
+++ b/materialized-view/src/test/java/com/msa/commerce/materializedview/adapter/in/kafka/KafkaConsumerConfigTest.java
@@ -1,0 +1,42 @@
+package com.msa.commerce.materializedview.adapter.in.kafka;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+
+@DisplayName("KafkaConsumerConfig 단위 테스트")
+class KafkaConsumerConfigTest {
+
+    private final KafkaConsumerConfig config = new KafkaConsumerConfig(new KafkaProperties());
+
+    @Test
+    @DisplayName("리스너 컨테이너 팩토리가 에러 핸들러와 함께 생성된다")
+    void createsListenerContainerFactories() {
+        CommonErrorHandler errorHandler = errorHandler();
+
+        assertThat(config.orderCreatedListenerContainerFactory(errorHandler)).isNotNull();
+        assertThat(config.orderUpdatedListenerContainerFactory(errorHandler)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("에러 핸들러는 재시도 후 DLT로 발행하는 DefaultErrorHandler다")
+    void createsDeadLetterErrorHandler() {
+        assertThat(errorHandler()).isInstanceOf(DefaultErrorHandler.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private KafkaTemplate<Object, Object> mockKafkaTemplate() {
+        return mock(KafkaTemplate.class);
+    }
+
+    private CommonErrorHandler errorHandler() {
+        return config.kafkaViewErrorHandler(mockKafkaTemplate());
+    }
+
+}

--- a/materialized-view/src/test/java/com/msa/commerce/materializedview/adapter/in/kafka/OrderEventConsumerTest.java
+++ b/materialized-view/src/test/java/com/msa/commerce/materializedview/adapter/in/kafka/OrderEventConsumerTest.java
@@ -1,0 +1,78 @@
+package com.msa.commerce.materializedview.adapter.in.kafka;
+
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.msa.commerce.materializedview.adapter.in.kafka.dto.EventMetadata;
+import com.msa.commerce.materializedview.adapter.in.kafka.dto.OrderCreatedEvent;
+import com.msa.commerce.materializedview.adapter.in.kafka.dto.OrderUpdatedEvent;
+import com.msa.commerce.materializedview.adapter.in.kafka.mapper.OrderViewMapper;
+import com.msa.commerce.materializedview.application.port.in.UpdateOrderViewUseCase;
+import com.msa.commerce.materializedview.domain.OrderCreatedView;
+import com.msa.commerce.materializedview.domain.OrderStatusChangedView;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OrderEventConsumer 단위 테스트")
+class OrderEventConsumerTest {
+
+    @Mock
+    private UpdateOrderViewUseCase updateOrderViewUseCase;
+
+    @Mock
+    private OrderViewMapper orderViewMapper;
+
+    @InjectMocks
+    private OrderEventConsumer orderEventConsumer;
+
+    @Test
+    @DisplayName("order.created 수신 시 뷰 갱신 유스케이스에 위임한다")
+    void delegatesOrderCreated() {
+        OrderCreatedEvent event = createdEvent();
+        OrderCreatedView view = new OrderCreatedView("event-1", event.orderId(), 1L,
+            BigDecimal.TEN, LocalDateTime.now(), List.of());
+        when(orderViewMapper.toView(event)).thenReturn(view);
+
+        orderEventConsumer.onOrderCreated(event);
+
+        verify(updateOrderViewUseCase).applyOrderCreated(view);
+    }
+
+    @Test
+    @DisplayName("order.updated 수신 시 상태 변경 유스케이스에 위임한다")
+    void delegatesOrderUpdated() {
+        OrderUpdatedEvent event = updatedEvent();
+        OrderStatusChangedView view = new OrderStatusChangedView("event-2", event.orderId(), 1L,
+            "SHIPPED", "DELIVERED", LocalDateTime.now());
+        when(orderViewMapper.toView(event)).thenReturn(view);
+
+        orderEventConsumer.onOrderUpdated(event);
+
+        verify(updateOrderViewUseCase).applyStatusChanged(view);
+    }
+
+    private OrderCreatedEvent createdEvent() {
+        return new OrderCreatedEvent(metadata("event-1"), UUID.randomUUID(), "ORD-1", 1L,
+            BigDecimal.TEN, "KRW", List.of(), "WEB", LocalDateTime.now());
+    }
+
+    private OrderUpdatedEvent updatedEvent() {
+        return new OrderUpdatedEvent(metadata("event-2"), UUID.randomUUID(), "ORD-1",
+            "SHIPPED", "DELIVERED", 1L, LocalDateTime.now(), null);
+    }
+
+    private EventMetadata metadata(String eventId) {
+        return new EventMetadata(eventId, "corr", LocalDateTime.now(), "TYPE", "src", 1);
+    }
+
+}

--- a/materialized-view/src/test/java/com/msa/commerce/materializedview/adapter/in/kafka/mapper/OrderViewMapperTest.java
+++ b/materialized-view/src/test/java/com/msa/commerce/materializedview/adapter/in/kafka/mapper/OrderViewMapperTest.java
@@ -1,0 +1,66 @@
+package com.msa.commerce.materializedview.adapter.in.kafka.mapper;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import com.msa.commerce.materializedview.adapter.in.kafka.dto.EventMetadata;
+import com.msa.commerce.materializedview.adapter.in.kafka.dto.OrderCreatedEvent;
+import com.msa.commerce.materializedview.adapter.in.kafka.dto.OrderUpdatedEvent;
+import com.msa.commerce.materializedview.domain.OrderCreatedView;
+import com.msa.commerce.materializedview.domain.OrderStatusChangedView;
+
+@DisplayName("OrderViewMapper 매핑 테스트")
+class OrderViewMapperTest {
+
+    private final OrderViewMapper mapper = Mappers.getMapper(OrderViewMapper.class);
+
+    @Test
+    @DisplayName("OrderCreatedEvent가 메타데이터의 eventId와 함께 매핑된다")
+    void mapsOrderCreatedEvent() {
+        UUID orderId = UUID.randomUUID();
+        OrderCreatedEvent event = new OrderCreatedEvent(
+            metadata("event-1"), orderId, "ORD-1", 7L, new BigDecimal("50000"), "KRW",
+            List.of(new OrderCreatedEvent.OrderItemData(101L, "무선 키보드", 2,
+                new BigDecimal("25000"), new BigDecimal("50000"))),
+            "WEB", LocalDateTime.of(2026, 7, 27, 10, 0));
+
+        OrderCreatedView view = mapper.toView(event);
+
+        assertThat(view.eventId()).isEqualTo("event-1");
+        assertThat(view.orderId()).isEqualTo(orderId);
+        assertThat(view.customerId()).isEqualTo(7L);
+        assertThat(view.orderItems()).singleElement().satisfies(item -> {
+            assertThat(item.productId()).isEqualTo(101L);
+            assertThat(item.quantity()).isEqualTo(2);
+            assertThat(item.totalPrice()).isEqualByComparingTo("50000");
+        });
+    }
+
+    @Test
+    @DisplayName("OrderUpdatedEvent가 상태 문자열과 함께 매핑된다")
+    void mapsOrderUpdatedEvent() {
+        OrderUpdatedEvent event = new OrderUpdatedEvent(
+            metadata("event-2"), UUID.randomUUID(), "ORD-1", "SHIPPED", "DELIVERED",
+            7L, LocalDateTime.of(2026, 7, 27, 12, 0), "배송 완료");
+
+        OrderStatusChangedView view = mapper.toView(event);
+
+        assertThat(view.eventId()).isEqualTo("event-2");
+        assertThat(view.previousStatus()).isEqualTo("SHIPPED");
+        assertThat(view.currentStatus()).isEqualTo("DELIVERED");
+        assertThat(view.completedDelta()).isEqualTo(1);
+    }
+
+    private EventMetadata metadata(String eventId) {
+        return new EventMetadata(eventId, "corr-1", LocalDateTime.now(), "TYPE", "order-orchestrator", 1);
+    }
+
+}

--- a/materialized-view/src/test/java/com/msa/commerce/materializedview/adapter/out/idempotency/RedisProcessedEventAdapterTest.java
+++ b/materialized-view/src/test/java/com/msa/commerce/materializedview/adapter/out/idempotency/RedisProcessedEventAdapterTest.java
@@ -1,0 +1,63 @@
+package com.msa.commerce.materializedview.adapter.out.idempotency;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RedisProcessedEventAdapter 단위 테스트")
+class RedisProcessedEventAdapterTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private RedisProcessedEventAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new RedisProcessedEventAdapter(redisTemplate);
+    }
+
+    @Test
+    @DisplayName("최초 처리 시 마크에 성공한다")
+    void marksFirstProcessing() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.setIfAbsent(eq("mv:processed-event:event-1"), eq("1"), any(Duration.class)))
+            .thenReturn(true);
+
+        assertThat(adapter.markProcessed("event-1")).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미 마크된 이벤트는 false를 반환한다")
+    void rejectsDuplicate() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class)))
+            .thenReturn(false);
+
+        assertThat(adapter.markProcessed("event-1")).isFalse();
+    }
+
+    @Test
+    @DisplayName("unmark는 처리 마크 키를 삭제한다")
+    void unmarkDeletesKey() {
+        adapter.unmark("event-1");
+
+        verify(redisTemplate).delete("mv:processed-event:event-1");
+    }
+
+}

--- a/materialized-view/src/test/java/com/msa/commerce/materializedview/adapter/out/persistence/OrderViewRepositoryAdapterTest.java
+++ b/materialized-view/src/test/java/com/msa/commerce/materializedview/adapter/out/persistence/OrderViewRepositoryAdapterTest.java
@@ -1,0 +1,88 @@
+package com.msa.commerce.materializedview.adapter.out.persistence;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import com.msa.commerce.materializedview.domain.OrderCreatedView;
+import com.msa.commerce.materializedview.domain.OrderStatusChangedView;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OrderViewRepositoryAdapter 단위 테스트")
+class OrderViewRepositoryAdapterTest {
+
+    private static final LocalDateTime ORDER_DATE = LocalDateTime.of(2026, 7, 27, 10, 0);
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @InjectMocks
+    private OrderViewRepositoryAdapter adapter;
+
+    @Test
+    @DisplayName("주문 생성 시 상품별 판매 집계와 사용자/일별 요약을 갱신한다")
+    void appliesOrderCreated() {
+        adapter.applyOrderCreated(createdView(2));
+
+        verify(jdbcTemplate).update(contains("INSERT INTO product_sales_summary"),
+            eq(101L), eq("무선 키보드"), eq(2), eq(new BigDecimal("50000")),
+            eq(new BigDecimal("25000.00")), eq(LocalDate.of(2026, 7, 27)), eq(LocalDate.of(2026, 7, 27)));
+        verify(jdbcTemplate).update(contains("INSERT INTO user_order_summary"),
+            eq(7L), any(), any(), any(), any(), any());
+        verify(jdbcTemplate).update(contains("INSERT INTO daily_business_metrics"),
+            eq(LocalDate.of(2026, 7, 27)), eq(new BigDecimal("50000")), eq(2));
+    }
+
+    @Test
+    @DisplayName("수량이 0인 항목은 평균 단가를 0으로 기록한다")
+    void zeroQuantityAveragePriceFallsBackToZero() {
+        adapter.applyOrderCreated(createdView(0));
+
+        verify(jdbcTemplate).update(contains("INSERT INTO product_sales_summary"),
+            eq(101L), eq("무선 키보드"), eq(0), eq(new BigDecimal("50000")),
+            eq(BigDecimal.ZERO), any(), any());
+    }
+
+    @Test
+    @DisplayName("카테고리가 바뀐 상태 변경은 카운터 갱신 쿼리를 수행한다")
+    void appliesStatusChangeAcrossCategories() {
+        adapter.applyStatusChanged(statusView("SHIPPED", "DELIVERED"));
+
+        verify(jdbcTemplate).update(contains("UPDATE user_order_summary"),
+            eq(-1), eq(1), eq(0), eq(7L));
+        verify(jdbcTemplate).update(contains("INSERT INTO daily_business_metrics"),
+            eq(LocalDate.of(2026, 7, 27)), eq(1), eq(0), eq(1), eq(0));
+    }
+
+    @Test
+    @DisplayName("같은 카테고리 내 상태 변경은 어떤 쿼리도 수행하지 않는다")
+    void skipsSameCategoryTransition() {
+        adapter.applyStatusChanged(statusView("PENDING", "CONFIRMED"));
+
+        verifyNoInteractions(jdbcTemplate);
+    }
+
+    private OrderCreatedView createdView(int quantity) {
+        return new OrderCreatedView("event-1", UUID.randomUUID(), 7L,
+            new BigDecimal("50000"), ORDER_DATE,
+            List.of(new OrderCreatedView.OrderItemView(101L, "무선 키보드", quantity, new BigDecimal("50000"))));
+    }
+
+    private OrderStatusChangedView statusView(String previous, String current) {
+        return new OrderStatusChangedView("event-2", UUID.randomUUID(), 7L, previous, current, ORDER_DATE);
+    }
+
+}

--- a/materialized-view/src/test/java/com/msa/commerce/materializedview/application/service/OrderViewServiceTest.java
+++ b/materialized-view/src/test/java/com/msa/commerce/materializedview/application/service/OrderViewServiceTest.java
@@ -1,0 +1,90 @@
+package com.msa.commerce.materializedview.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.msa.commerce.materializedview.application.port.out.OrderViewRepository;
+import com.msa.commerce.materializedview.application.port.out.ProcessedEventPort;
+import com.msa.commerce.materializedview.domain.OrderCreatedView;
+import com.msa.commerce.materializedview.domain.OrderStatusChangedView;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OrderViewService 단위 테스트")
+class OrderViewServiceTest {
+
+    @Mock
+    private ProcessedEventPort processedEventPort;
+
+    @Mock
+    private OrderViewRepository orderViewRepository;
+
+    @InjectMocks
+    private OrderViewService orderViewService;
+
+    @Test
+    @DisplayName("신규 이벤트는 뷰 갱신을 수행한다")
+    void appliesNewEvent() {
+        when(processedEventPort.markProcessed("event-1")).thenReturn(true);
+
+        orderViewService.applyOrderCreated(createdView());
+
+        verify(orderViewRepository).applyOrderCreated(any(OrderCreatedView.class));
+    }
+
+    @Test
+    @DisplayName("이미 처리한 이벤트는 뷰 갱신 없이 건너뛴다")
+    void skipsDuplicateEvent() {
+        when(processedEventPort.markProcessed("event-1")).thenReturn(false);
+
+        orderViewService.applyOrderCreated(createdView());
+
+        verify(orderViewRepository, never()).applyOrderCreated(any(OrderCreatedView.class));
+    }
+
+    @Test
+    @DisplayName("뷰 갱신 실패 시 처리 마크를 되돌리고 예외를 다시 던진다")
+    void unmarksOnFailure() {
+        when(processedEventPort.markProcessed("event-1")).thenReturn(true);
+        doThrow(new IllegalStateException("db down"))
+            .when(orderViewRepository).applyOrderCreated(any(OrderCreatedView.class));
+
+        assertThatThrownBy(() -> orderViewService.applyOrderCreated(createdView()))
+            .isInstanceOf(IllegalStateException.class);
+
+        verify(processedEventPort).unmark("event-1");
+    }
+
+    @Test
+    @DisplayName("상태 변경 이벤트도 동일한 멱등 처리 흐름을 따른다")
+    void appliesStatusChangedEvent() {
+        when(processedEventPort.markProcessed("event-2")).thenReturn(true);
+
+        orderViewService.applyStatusChanged(statusChangedView());
+
+        verify(orderViewRepository).applyStatusChanged(any(OrderStatusChangedView.class));
+    }
+
+    private OrderCreatedView createdView() {
+        return new OrderCreatedView("event-1", UUID.randomUUID(), 1L,
+            new BigDecimal("50000"), LocalDateTime.now(),
+            List.of(new OrderCreatedView.OrderItemView(101L, "무선 키보드", 2, new BigDecimal("50000"))));
+    }
+
+    private OrderStatusChangedView statusChangedView() {
+        return new OrderStatusChangedView("event-2", UUID.randomUUID(), 1L,
+            "SHIPPED", "DELIVERED", LocalDateTime.now());
+    }
+
+}

--- a/materialized-view/src/test/java/com/msa/commerce/materializedview/domain/OrderStatusChangedViewTest.java
+++ b/materialized-view/src/test/java/com/msa/commerce/materializedview/domain/OrderStatusChangedViewTest.java
@@ -1,0 +1,72 @@
+package com.msa.commerce.materializedview.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("OrderStatusChangedView 상태 전이 델타 테스트")
+class OrderStatusChangedViewTest {
+
+    @Test
+    @DisplayName("SHIPPED → DELIVERED: 진행중 -1, 완료 +1")
+    void shippedToDelivered() {
+        OrderStatusChangedView view = view("SHIPPED", "DELIVERED");
+
+        assertThat(view.hasCategoryChanged()).isTrue();
+        assertThat(view.pendingDelta()).isEqualTo(-1);
+        assertThat(view.completedDelta()).isEqualTo(1);
+        assertThat(view.cancelledDelta()).isZero();
+    }
+
+    @Test
+    @DisplayName("PENDING → CANCELLED: 진행중 -1, 취소 +1")
+    void pendingToCancelled() {
+        OrderStatusChangedView view = view("PENDING", "CANCELLED");
+
+        assertThat(view.pendingDelta()).isEqualTo(-1);
+        assertThat(view.completedDelta()).isZero();
+        assertThat(view.cancelledDelta()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("DELIVERED → REFUNDED: 완료 -1, 취소 +1")
+    void deliveredToRefunded() {
+        OrderStatusChangedView view = view("DELIVERED", "REFUNDED");
+
+        assertThat(view.pendingDelta()).isZero();
+        assertThat(view.completedDelta()).isEqualTo(-1);
+        assertThat(view.cancelledDelta()).isEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"PENDING,CONFIRMED", "CONFIRMED,PAYMENT_PENDING", "PAID,PROCESSING", "PROCESSING,SHIPPED"})
+    @DisplayName("진행중 카테고리 내부 전이는 카운터 변화 없음")
+    void transitionsWithinActiveCategory(String previous, String current) {
+        OrderStatusChangedView view = view(previous, current);
+
+        assertThat(view.hasCategoryChanged()).isFalse();
+        assertThat(view.pendingDelta()).isZero();
+        assertThat(view.completedDelta()).isZero();
+        assertThat(view.cancelledDelta()).isZero();
+    }
+
+    @Test
+    @DisplayName("알 수 없는 상태 문자열은 진행중으로 분류되어 안전하게 처리")
+    void unknownStatusFallsBackToActive() {
+        OrderStatusChangedView view = view("PENDING", "SOME_FUTURE_STATUS");
+
+        assertThat(view.hasCategoryChanged()).isFalse();
+    }
+
+    private OrderStatusChangedView view(String previous, String current) {
+        return new OrderStatusChangedView(
+            "event-1", UUID.randomUUID(), 1L, previous, current, LocalDateTime.now());
+    }
+
+}


### PR DESCRIPTION
## 📋 PR 요약

Kafka `order.created` / `order.updated` 이벤트를 구독해 `db_materialized_view`의 조회용 요약 테이블 3종(상품 판매·사용자 주문·일별 지표)을 실시간 갱신하는 CQRS Read Model 워커를 구현합니다.

### 🔗 관련 이슈

- Closes #48
- Related to #46 (본 워커가 소비하는 이벤트 파이프라인, PR #70)

### 📝 변경 사항

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 테스트 코드 추가/수정

### 🛠️ 기술적 변경 사항

**처리 흐름**

```
order.created / order.updated (Kafka)
    → OrderEventConsumer (JsonDeserializer, 발행측 타입 헤더 무시)
    → OrderViewMapper (MapStruct) → OrderViewService
    → Redis SETNX 멱등 처리 (24h TTL, 실패 시 unmark로 재시도 보장)
    → OrderViewRepositoryAdapter — 원자적 upsert (ON DUPLICATE KEY)
    → product_sales_summary / user_order_summary / daily_business_metrics
    ↘ 처리 실패 시: 지수 백오프 3회 재시도 → dead.letter.queue 이관
```

**새로 추가된 파일** (materialized-view, 헥사고날 구조)

- `adapter/in/kafka` — `OrderEventConsumer`, `KafkaConsumerConfig`(재시도+DLT), 소비자측 이벤트 DTO 3종, MapStruct 매퍼
- `application` — `UpdateOrderViewUseCase`, `OrderViewService`(멱등 처리), out port 2종
- `domain` — `OrderCreatedView`, `OrderStatusChangedView`(상태 전이 델타 계산), `OrderStatusCategory`
- `adapter/out/persistence` — `OrderViewRepositoryAdapter`(JdbcTemplate native upsert)
- `adapter/out/idempotency` — `RedisProcessedEventAdapter`

**주요 설계 판단**

- **소비자측 이벤트 계약 자체 정의**: order-orchestrator 모듈에 의존하지 않고 DTO를 자체 보유. status는 String으로 수신해 발행측 enum이 추가되어도 역직렬화가 깨지지 않음
- **원자적 upsert**: read-modify-write 대신 `ON DUPLICATE KEY UPDATE`로 동시 소비 레이스 제거. MySQL 9.4에서 `VALUES()` 함수가 deprecated라 row alias(`AS new`) 문법 사용
- **LIFETIME 행 sentinel 날짜(1970-01-01)**: unique key에서 NULL은 중복을 허용하므로 NULL 기간이면 upsert가 매번 새 행을 생성함. sentinel로 회피
- **상태 카운터**: `OrderStatusCategory`(ACTIVE/COMPLETED/CANCELLED) 분류 후 델타 계산. 같은 카테고리 내 전이(PENDING→CONFIRMED 등)는 쿼리 자체를 생략

**수정된 파일 (기존 버그 3건)**

- `application.yml` — datasource DB명 `materialized_view_db` → 실제 스키마 `db_materialized_view`, local 프로필 redis host `redis` → `localhost`, 존재하지 않는 trusted package 설정 제거
- `build.gradle.kts` — MapStruct 의존성 추가

### 🧪 테스트

- [x] 단위 테스트 통과 — 7클래스 25건
- [x] JaCoCo 커버리지 게이트 통과 (클래스 80% / 브랜치 60%)
- [ ] 통합 테스트 — Testcontainers 1.21.3 ↔ Docker 29.6.2 비호환으로 로컬 실행 불가(선행 이슈), 해소 후 추가 예정

**테스트 방법:**

1. `./gradlew :materialized-view:build`
2. `cd infra/docker && docker-compose up -d` 후 `./gradlew :materialized-view:bootRun`
3. order-orchestrator에서 주문 생성 → `db_materialized_view.product_sales_summary` 등 집계 반영 확인
4. 같은 이벤트 재전달 시 중복 집계되지 않음(Redis 멱등 키) 확인

### 📊 성능 영향

- [x] 성능에 영향 없음 (비동기 소비, 단건당 upsert 3~4회)

### 🔍 리뷰 포인트

- `OrderViewRepositoryAdapter`의 upsert SQL — 집계 산식(평균가, 누적 매출)과 sentinel 날짜 방식
- 멱등 처리 순서 — mark 후 실패 시 unmark 방식의 트레이드오프 (동시 재전달 시 이중 처리 창 vs 유실)

### 💬 추가 메모 (알려진 한계, 후속 과제)

1. `product_sku` — `order.created` 이벤트에 SKU 필드가 없어 빈 값으로 기록. 발행측 `OrderItemData` 스키마 확장 후 채울 예정
2. `unique_customers` — 이벤트만으로 distinct 집계 불가, 별도 설계 필요
3. 주문 생성 전 상태 변경 이벤트가 먼저 도착하는 순서 역전 시 `user_order_summary` UPDATE는 no-op (daily 지표는 upsert라 안전)
