### PR TITLE
fix: Testcontainers Docker 29 호환 및 order-orchestrator 기동 불가 버그 수정

### DIFF
--- a/buildSrc/src/main/java/CommonPlugin.java
+++ b/buildSrc/src/main/java/CommonPlugin.java
@@ -38,6 +38,12 @@ public class CommonPlugin implements Plugin<Project> {
         project.getPluginManager().apply(Plugins.SPRING_DEPENDENCY_MANAGEMENT.getId());
         project.getPluginManager().apply(JacocoPlugin.class);
         project.getPluginManager().apply(QueryDslPlugin.class);
+        overrideBomVersions(project);
+    }
+
+    private void overrideBomVersions(Project project) {
+        project.getExtensions().getExtraProperties()
+            .set("testcontainers.version", Version.TESTCONTAINERS.getVersion());
     }
 
     private void configureJava(Project project) {

--- a/buildSrc/src/main/java/Version.java
+++ b/buildSrc/src/main/java/Version.java
@@ -4,6 +4,8 @@ public enum Version {
     SONARQUBE("6.2.0.5505"),
     FLYWAY("10.21.0"),
     QUERYDSL_PLUGIN("1.0.10"),
+    // Spring Boot 3.5.4 BOM의 1.21.3은 Docker Engine 29와 비호환 (docker-java /info 400)
+    TESTCONTAINERS("1.21.4"),
     JAVA_VERSION("21");
 
     private final String version;

--- a/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/adapter/out/kafka/KafkaProducerConfig.java
+++ b/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/adapter/out/kafka/KafkaProducerConfig.java
@@ -1,0 +1,21 @@
+package com.msa.commerce.orchestrator.adapter.out.kafka;
+
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+
+// RetryEventPublisher(@Qualifier("objectKafkaTemplate"))와 CrossDomainEventRelay가
+// 요구하는 KafkaTemplate<String, Object> 빈. Boot 자동구성 템플릿은 <Object, Object>라
+// 제네릭이 맞지 않아 별도로 정의한다.
+@Configuration
+public class KafkaProducerConfig {
+
+    @Bean
+    public KafkaTemplate<String, Object> objectKafkaTemplate(KafkaProperties kafkaProperties) {
+        return new KafkaTemplate<>(
+            new DefaultKafkaProducerFactory<>(kafkaProperties.buildProducerProperties(null)));
+    }
+
+}

--- a/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/domain/crossdomain/CrossDomainEvent.java
+++ b/order-orchestrator/src/main/java/com/msa/commerce/orchestrator/domain/crossdomain/CrossDomainEvent.java
@@ -2,6 +2,7 @@ package com.msa.commerce.orchestrator.domain.crossdomain;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -93,6 +94,7 @@ public class CrossDomainEvent {
             entityId, eventData, kafkaTopic);
 
         return CrossDomainEvent.builder()
+            .eventUuid(UUID.randomUUID().toString())
             .eventType(eventType)
             .sourceDomain(sourceDomain)
             .targetDomains(targetDomains)

--- a/order-orchestrator/src/test/java/com/msa/commerce/orchestrator/adapter/out/crossdomain/CrossDomainEventRelayIntegrationTest.java
+++ b/order-orchestrator/src/test/java/com/msa/commerce/orchestrator/adapter/out/crossdomain/CrossDomainEventRelayIntegrationTest.java
@@ -24,6 +24,7 @@ import org.springframework.kafka.test.utils.ContainerTestUtils;
 
 import com.msa.commerce.orchestrator.adapter.out.kafka.KafkaIntegrationTestBase;
 import com.msa.commerce.orchestrator.adapter.out.kafka.KafkaTopics;
+import com.msa.commerce.orchestrator.adapter.out.persistence.CrossDomainEventJpaRepository;
 import com.msa.commerce.orchestrator.application.port.out.CrossDomainEventRepository;
 import com.msa.commerce.orchestrator.application.port.out.OrderEventPublisher;
 import com.msa.commerce.orchestrator.domain.Order;
@@ -40,6 +41,9 @@ class CrossDomainEventRelayIntegrationTest extends KafkaIntegrationTestBase {
     private CrossDomainEventRepository crossDomainEventRepository;
 
     @Autowired
+    private CrossDomainEventJpaRepository crossDomainEventJpaRepository;
+
+    @Autowired
     private CrossDomainEventRelay crossDomainEventRelay;
 
     private KafkaMessageListenerContainer<String, OrderCreatedEvent> container;
@@ -48,6 +52,7 @@ class CrossDomainEventRelayIntegrationTest extends KafkaIntegrationTestBase {
 
     @BeforeEach
     void setUp() {
+        crossDomainEventJpaRepository.deleteAll();
         setupConsumer();
     }
 
@@ -74,7 +79,7 @@ class CrossDomainEventRelayIntegrationTest extends KafkaIntegrationTestBase {
             .atMost(5, TimeUnit.SECONDS)
             .untilAsserted(() -> assertThat(receivedEvent).isNotNull());
 
-        assertThat(receivedEvent.getOrderId()).isEqualTo(order.getOrderId().toString());
+        assertThat(receivedEvent.getOrderId()).isEqualTo(order.getOrderId());
         assertThat(receivedEvent.getOrderNumber()).isEqualTo(order.getOrderNumber());
         assertThat(receivedEvent.getTotalAmount()).isEqualByComparingTo(order.getTotalAmount());
 
@@ -143,6 +148,8 @@ class CrossDomainEventRelayIntegrationTest extends KafkaIntegrationTestBase {
         consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
         consumerProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
         consumerProps.put(JsonDeserializer.VALUE_DEFAULT_TYPE, OrderCreatedEvent.class.getName());
+        // 릴레이는 Map으로 재직렬화해 발행하므로 타입 헤더 대신 기본 타입으로 역직렬화한다
+        consumerProps.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
 
         DefaultKafkaConsumerFactory<String, OrderCreatedEvent> consumerFactory =
             new DefaultKafkaConsumerFactory<>(consumerProps);

--- a/order-orchestrator/src/test/java/com/msa/commerce/orchestrator/adapter/out/kafka/KafkaIntegrationTestBase.java
+++ b/order-orchestrator/src/test/java/com/msa/commerce/orchestrator/adapter/out/kafka/KafkaIntegrationTestBase.java
@@ -24,6 +24,8 @@ public abstract class KafkaIntegrationTestBase {
             .withDatabaseName("test_order_db")
             .withUsername("test")
             .withPassword("test")
+            // 기본 my.cnf의 innodb_log_file_size가 MySQL 9에서 제거되어 기동에 실패하므로 오버라이드
+            .withConfigurationOverride("testcontainers/mysql-conf")
             .withReuse(true);
 
     @DynamicPropertySource
@@ -32,6 +34,8 @@ public abstract class KafkaIntegrationTestBase {
         registry.add("spring.datasource.url", MYSQL_CONTAINER::getJdbcUrl);
         registry.add("spring.datasource.username", MYSQL_CONTAINER::getUsername);
         registry.add("spring.datasource.password", MYSQL_CONTAINER::getPassword);
+        // 컨테이너는 빈 DB로 시작하므로 validate 대신 엔티티 기준으로 스키마를 생성한다
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
     }
 
 }

--- a/order-orchestrator/src/test/resources/testcontainers/mysql-conf/my.cnf
+++ b/order-orchestrator/src/test/resources/testcontainers/mysql-conf/my.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+# Testcontainers 기본 my.cnf의 innodb_log_file_size는 MySQL 8.4+에서 제거된 변수라
+# mysql:9.4.0 기동이 실패한다. 빈 설정으로 오버라이드해 서버 기본값을 사용한다.


### PR DESCRIPTION
## 📋 PR 요약

Testcontainers ↔ Docker 29 비호환을 수정하는 과정에서 **order-orchestrator의 프로덕션 버그 2건**(기동 불가, Outbox 저장 실패)을 발견해 함께 수정합니다.

> ⚠️ **우선 머지 권장**: 현재 develop의 order-orchestrator는 기동 자체가 불가능한 상태입니다. 리뷰 중인 다른 PR들(#71/#75/#76)보다 먼저 머지하면 각 PR의 CI에도 자동 반영됩니다.

### 🔗 관련 이슈

- Related to #46 (PR #70의 잔여 버그 수정)

### 📝 변경 사항

- [x] 버그 수정
- [x] 테스트 코드 추가/수정

### 🛠️ 기술적 변경 사항

문제가 5겹으로 중첩되어 있었습니다. 발견 순서대로:

**1. Testcontainers 1.21.3 ↔ Docker 29.6.2 비호환** (원래 목표)
- docker-java가 `/info` 호출에서 400을 받아 Docker 환경 탐지 실패 → 통합 테스트 4클래스 전부 `initializationError`
- Spring Boot 3.5.4 BOM이 1.21.3을 관리하므로 `CommonPlugin`에서 `testcontainers.version` 프로퍼티로 **1.21.4** 오버라이드
- 2.0.5(최신)는 테스트가 쓰는 `KafkaContainer` 클래스가 제거되어 코드 수정이 필요해 보류

**2. TC 기본 my.cnf가 MySQL 9 기동을 차단**
- Testcontainers가 주입하는 기본 설정의 `innodb_log_file_size`는 MySQL 8.4+에서 제거된 변수 → `mysql:9.4.0` 컨테이너 exit 1
- 빈 `my.cnf`로 `withConfigurationOverride` 처리

**3. 빈 컨테이너 DB + `ddl-auto: validate`**
- 테스트 컨테이너는 빈 DB로 시작하므로 스키마 검증에서 컨텍스트 로드 실패
- `KafkaIntegrationTestBase`에서 `create-drop` 오버라이드

**4. 🔥 프로덕션 버그: 애플리케이션 기동 불가**
- `RetryEventPublisher`가 요구하는 `@Qualifier("objectKafkaTemplate")` 빈이 **어디에도 정의되어 있지 않음**
- common의 `KafkaConfig`는 빈 이름이 다르고(`kafkaTemplate`), orchestrator의 `scanBasePackages`(`common.exception`만 포함)에서 로드되지도 않음
- `CrossDomainEventRelay`의 `KafkaTemplate<String, Object>` 주입도 Boot 자동구성(`<Object, Object>`)과 제네릭 불일치
- → `KafkaProducerConfig` 신설로 두 주입 지점 모두 해결

**5. 🔥 프로덕션 버그: Outbox 저장 항상 실패**
- `CrossDomainEvent.create()` 팩토리가 NOT NULL 컬럼인 `eventUuid`를 설정하지 않음
- 주문 생성 시마다 `DataIntegrityViolationException` → 이벤트 발행 전체 불능
- → 팩토리에서 UUID 생성 추가

**테스트 수정** (`CrossDomainEventRelayIntegrationTest`)
- 릴레이는 eventData를 Map으로 재직렬화해 발행하므로 테스트 컨슈머가 타입 헤더를 무시하도록 수정 (`USE_TYPE_INFO_HEADERS=false`)
- UUID를 String과 비교하던 단언 수정
- 테스트 간 outbox 테이블 오염 방지 (`@BeforeEach` cleanup)

### 🧪 테스트

- [x] `CrossDomainEventRelayIntegrationTest` **2/2 green — 도입(#70) 이후 최초로 통과**
- [x] 단위 테스트 135건 회귀 없음
- [ ] 잔여: `KafkaErrorHandler`(3)/`PaymentResultConsumer`(2)/`RetryConsumer`(2) — 공유 컨텍스트 캐시 + 동일 consumer group 경합이라는 **테스트 격리 설계 문제**로, 별도 이슈로 분리 (본 PR 범위 외)

**테스트 방법:**

1. Docker 29.x 환경에서 `./gradlew :order-orchestrator:test --tests "*CrossDomainEventRelayIntegrationTest"`
2. `./gradlew :order-orchestrator:bootRun` — 수정 전에는 `UnsatisfiedDependencyException`으로 기동 실패, 수정 후 정상 기동

### 🎯 배포 고려사항

- 이 수정 없이는 order-orchestrator 배포/기동이 불가능합니다 (develop 현재 상태)

### 💬 추가 메모

- 교훈: 통합 테스트가 실행 불가능한 상태로 머지되면 그 뒤에 숨은 버그의 수를 알 수 없게 됩니다. #70의 통합 테스트 4클래스는 한 번도 green인 적 없이 머지되었고, 그 뒤에 기동 불가 수준의 버그 2개가 숨어 있었습니다.
- Testcontainers 2.x 업그레이드는 `KafkaContainer` → `ConfluentKafkaContainer` 마이그레이션과 함께 별도 작업으로 진행 권장
